### PR TITLE
fix https error

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "postcss-safe-parser": "4.0.1",
     "react": "^16.12.0",
     "react-app-polyfill": "^1.0.5",
-    "react-dev-utils": "^10.0.0",
+    "react-dev-utils": "^10.1.0",
     "react-dom": "^16.12.0",
     "resolve": "1.12.2",
     "resolve-url-loader": "3.1.1",


### PR DESCRIPTION
你好，
我发现项目如果用 https 部署的话，websocket 就会报错，因为默认用得是 ws，而 https 要求 wss，这个 bug 在新版本的 react-dev-utils 里面修复了，会自动根据 http/https 选择 ws/wss：

https://github.com/facebook/create-react-app/pull/8079/files

更新版本后 https 就没问题了：

    serve -s build

https://covid19.wuhanstudio.team/